### PR TITLE
Add an integration test

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,3 +14,4 @@ jobs:
       juju-channel: 3/stable
       provider: 'lxd'
       pre-run-script: ./tests/integration/setup-integration-tests.sh
+      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,4 +14,3 @@ jobs:
       juju-channel: 3/stable
       provider: 'lxd'
       pre-run-script: ./tests/integration/setup-integration-tests.sh
-      tmate-debug: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,6 +8,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
       juju-channel: 3/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,17 +8,8 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      load-test-enabled: false
-      load-test-run-args: "-e LOAD_TEST_HOST=localhost"
-      zap-before-command: "curl -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"
-      zap-enabled: true
-      zap-cmd-options: '-T 60 -z "-addoninstall jython" --hook "/zap/wrk/tests/zap/hook.py"'
-      zap-target: localhost
-      zap-target-port: 80
-      zap-rules-file-name: "zap_rules.tsv"
-      trivy-fs-enabled: true
-      trivy-image-config: "trivy.yaml"
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
-      juju-channel: '3/stable'
-      channel: '1.32-strict/stable'
+      juju-channel: 3/stable
+      provider: 'lxd'
+      pre-run-script: ./tests/integration/setup-integration-tests.sh

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ mv ${selector}.txt ${domain?}-${selector}.txt
 Then copy out the keys:
 
 ```
-units="$(juju status dkim-signing | grep '^dkim-signing/[0-9]*' -o | sort -r)"
+units="$(juju status smtp-dkim-signing | grep '^smtp-dkim-signing/[0-9]*' -o | sort -r)"
 for unit in $units; do
     echo "*** ${unit} ***"
-    juju run --unit ${unit} "sudo -iu ubuntu mkdir -p ~ubuntu/opendkim-keys; chmod go-rwx ~ubuntu/opendkim-keys"
+    juju exec --unit ${unit} "sudo -iu ubuntu mkdir -p ~ubuntu/opendkim-keys; chmod go-rwx ~ubuntu/opendkim-keys"
     juju scp ${domain?}-${selector}.private ${unit}:opendkim-keys/
-    juju run --unit ${unit} "mv ~ubuntu/opendkim-keys/*.private /etc/dkimkeys/; chown -R opendkim: /etc/dkimkeys/; chmod -R go-rwx /etc/dkimkeys/"
+    juju exec --unit ${unit} "mv ~ubuntu/opendkim-keys/*.private /etc/dkimkeys/; chown -R opendkim: /etc/dkimkeys/; chmod -R go-rwx /etc/dkimkeys/"
 done
 ```
 TODO: Include config option or action to copy/push these keys out.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,22 +4,14 @@
 type: "charm"
 bases:
     - build-on:
-      # Can't build using Focal, although, probably best to default to build
-      # with Jammy from now on. See:
-      #     https://github.com/canonical/charmcraft/issues/904
-      # - name: "ubuntu"
-      #   channel: "20.04"
       - name: "ubuntu"
         channel: "22.04"
-      - name: "ubuntu"
-        channel: "22.10"
       run-on:
-      - name: "ubuntu"
-        channel: "20.04"
       - name: "ubuntu"
         channel: "22.04"
 parts:
   charm:
     source: "."
     plugin: "reactive"
-    build-snaps: [charm]
+    build-snaps:
+      - charm/3.x/stable

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from collections.abc import Generator
 import jubilant
 import pytest
 
+
 @pytest.fixture(scope="module", name="smtp_dkim_signing_charm")
 def smtp_dkim_signing_charm_fixture(pytestconfig: pytest.Config):
     """Get value from parameter charm-file."""
@@ -59,8 +60,8 @@ def deploy_smtp_relay_fixture(
     return smtp_relay_app_name
 
 
-@pytest.fixture(scope="session")
-def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+@pytest.fixture(scope="session", name="juju")
+def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
     """Pytest fixture that wraps :meth:`jubilant.with_model`."""
 
     def show_debug_log(juju: jubilant.Juju):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ def deploy_smtp_dkim_signing_fixture(
     juju.wait(
         lambda status: status.apps[deploy_smtp_dkim_signing_name].is_active,
         error=jubilant.any_blocked,
-        timeout=15 * 60,
+        timeout=10 * 60,
     )
     return deploy_smtp_dkim_signing_name
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for charm integration tests."""
+
+import typing
+from collections.abc import Generator
+
+import jubilant
+import pytest
+
+
+@pytest.fixture(scope="module", name="smtp_dkim_signing_charm")
+def smtp_dkim_signing_charm_fixture(pytestconfig: pytest.Config):
+    """Get value from parameter charm-file."""
+    charm = pytestconfig.getoption("--charm-file")
+    use_existing = pytestconfig.getoption("--use-existing", default=False)
+    if not use_existing:
+        assert charm, "--charm-file must be set"
+    return charm
+
+
+@pytest.fixture(scope="module", name="smtp_dkim_signing_app")
+def deploy_smtp_dkim_signing_fixture(
+    smtp_dkim_signing_charm: str,
+    juju: jubilant.Juju,
+) -> str:
+    """Deploy smtp-dkim-signing."""
+    deploy_smtp_dkim_signing_name = "smtp-dkim-signing"
+
+    if not juju.status().apps.get(deploy_smtp_dkim_signing_name):
+        juju.deploy(
+            f"./{smtp_dkim_signing_charm}",
+            deploy_smtp_dkim_signing_name,
+        )
+    juju.wait(
+        lambda status: status.apps[deploy_smtp_dkim_signing_name].is_active,
+        error=jubilant.any_blocked,
+        timeout=6 * 60,
+    )
+    return deploy_smtp_dkim_signing_name
+
+
+@pytest.fixture(scope="module", name="smtp_relay_app")
+def deploy_smtp_relay_fixture(
+    smtp_dkim_signing_app: str,
+    juju: jubilant.Juju,
+) -> str:
+    """Deploy smtp-relay and integrate with dkim."""
+    smtp_relay_app_name = "smtp-relay"
+
+    if not juju.status().apps.get(smtp_relay_app_name):
+        juju.deploy(smtp_relay_app_name, smtp_relay_app_name)
+        juju.integrate(smtp_relay_app_name, smtp_dkim_signing_app)
+    juju.wait(
+        lambda status: jubilant.all_active(status, smtp_relay_app_name, smtp_dkim_signing_app),
+        error=jubilant.any_blocked,
+        timeout=6 * 60,
+    )
+    return smtp_relay_app_name
+
+
+@pytest.fixture(scope="session")
+def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+    """Pytest fixture that wraps :meth:`jubilant.with_model`."""
+
+    def show_debug_log(juju: jubilant.Juju):
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            print(log, end="")
+
+    use_existing = request.config.getoption("--use-existing", default=False)
+    if use_existing:
+        juju = jubilant.Juju()
+        yield juju
+        show_debug_log(juju)
+        return
+
+    model = request.config.getoption("--model")
+    if model:
+        juju = jubilant.Juju(model=model)
+        yield juju
+        show_debug_log(juju)
+        return
+
+    keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 10 * 60
+        yield juju
+        show_debug_log(juju)
+        return

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,6 +72,7 @@ def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, Non
     use_existing = request.config.getoption("--use-existing", default=False)
     if use_existing:
         juju = jubilant.Juju()
+        juju.model_config({"automatically-retry-hooks": True})
         yield juju
         show_debug_log(juju)
         return
@@ -79,6 +80,7 @@ def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, Non
     model = request.config.getoption("--model")
     if model:
         juju = jubilant.Juju(model=model)
+        juju.model_config({"automatically-retry-hooks": True})
         yield juju
         show_debug_log(juju)
         return

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ from collections.abc import Generator
 import jubilant
 import pytest
 
-
 @pytest.fixture(scope="module", name="smtp_dkim_signing_charm")
 def smtp_dkim_signing_charm_fixture(pytestconfig: pytest.Config):
     """Get value from parameter charm-file."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ def deploy_smtp_dkim_signing_fixture(
     juju.wait(
         lambda status: status.apps[deploy_smtp_dkim_signing_name].is_active,
         error=jubilant.any_blocked,
-        timeout=6 * 60,
+        timeout=10 * 60,
     )
     return deploy_smtp_dkim_signing_name
 
@@ -55,7 +55,7 @@ def deploy_smtp_relay_fixture(
     juju.wait(
         lambda status: jubilant.all_active(status, smtp_relay_app_name, smtp_dkim_signing_app),
         error=jubilant.any_blocked,
-        timeout=6 * 60,
+        timeout=10 * 60,
     )
     return smtp_relay_app_name
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ def deploy_smtp_dkim_signing_fixture(
     juju.wait(
         lambda status: status.apps[deploy_smtp_dkim_signing_name].is_active,
         error=jubilant.any_blocked,
-        timeout=10 * 60,
+        timeout=15 * 60,
     )
     return deploy_smtp_dkim_signing_name
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,6 +88,7 @@ def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, Non
     keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
     with jubilant.temp_model(keep=keep_models) as juju:
         juju.wait_timeout = 10 * 60
+        juju.model_config({"automatically-retry-hooks": True})
         yield juju
         show_debug_log(juju)
         return

--- a/tests/integration/setup-integration-tests.sh
+++ b/tests/integration/setup-integration-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+set -euxo pipefail
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install opendkim-tools
+sudo docker run --rm -d -p 1080:1080 -p 25:1025 sj26/mailcatcher

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,7 +35,6 @@ def generate_opendkim_genkey(domain: str, selector: str) -> typing.Tuple[str, st
         The txt record and the private key.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
-        logger.info("JAVI TEMPDIR: %s", tmpdirname)
         subprocess.run(  # nosec
             ["opendkim-genkey", "-s", selector, "-d", domain], check=True, cwd=tmpdirname
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests."""
+
+import logging
+import pathlib
+import smtplib
+import socket
+import subprocess  # nosec B404
+import tempfile
+import time
+
+import jubilant
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def generate_opendkim_genkey(domain: str, selector: str) -> (str, str):
+    # Returns txt, private
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        logger.info("JAVI TEMPDIR: %s", tmpdirname)
+        subprocess.run(  # nosec
+            ["opendkim-genkey", "-s", selector, "-d", domain], check=True, cwd=tmpdirname
+        )
+        # Two files should have been created, {selector}.txt and {selector}.private
+        txt_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.txt")).read_text()
+        private_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.private")).read_text()
+        return txt_data, private_data
+
+
+@pytest.fixture(scope="session", name="machine_ip_address")
+def machine_ip_address_fixture() -> str:
+    """IP address for the machine running the tests."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    ip_address = s.getsockname()[0]
+    logger.info("IP Address for the current test runner: %s", ip_address)
+    s.close()
+    return ip_address
+
+
+@pytest.mark.abort_on_fail
+def test_simple_relay_dkim(
+    juju: jubilant.Juju, smtp_dkim_signing_app, smtp_relay_app, machine_ip_address
+):
+    """
+    arrange: Deploy smtp-relay charm with the testrelay.internal domain in relay domains.
+    act: Send an email to an address with the testrelay.internal domain.
+    assert: The email is correctly relayed to the mailcatcher local test smtp server.
+    """
+    status = juju.status()
+    unit = list(status.apps[smtp_relay_app].units.values())[0]
+    unit_ip = unit.public_address
+
+    dkim_unit = list(status.apps[smtp_dkim_signing_app].units.keys())[0]
+
+    domain = "testrelay.internal"
+    selector = "default"
+    _, private_key = generate_opendkim_genkey(domain=domain, selector=selector)
+    with tempfile.NamedTemporaryFile(dir=".") as tf:
+        tf.write(private_key.encode("utf-8"))
+        tf.flush()
+        juju.scp(tf.name, f"{dkim_unit}:/tmp/{domain}-{selector}.private")
+        juju.exec(
+            f"mv /tmp/{domain}-{selector}.private /etc/dkimkeys/; chown -R opendkim: /etc/dkimkeys/; chmod -R go-rwx /etc/dkimkeys/",
+            unit=dkim_unit,
+        )
+
+    juju.config(
+        smtp_dkim_signing_app,
+        {
+            "selector": selector,
+            "keytable": f"{selector}._domainkey.{domain} {domain}:{selector}:/etc/dkimkeys/{domain}-{selector}.private",
+            "signingtable": f"*@{domain} {selector}._domainkey.{domain}",
+        },
+    )
+
+    # The charm does not restart opendkim on changes in the config values.
+    juju.exec("systemctl restart opendkim", unit=dkim_unit)
+
+    command_to_put_domain = (
+        f"echo {machine_ip_address} testrelay.internal | sudo tee -a /etc/hosts"
+    )
+    juju.exec(machine=unit.machine, command=command_to_put_domain)
+
+    juju.config(smtp_relay_app, {"relay_domains": "- testrelay.internal"})
+    juju.wait(
+        lambda status: status.apps[smtp_relay_app].is_active,
+        error=jubilant.any_blocked,
+        timeout=6 * 60,
+    )
+
+    mailcatcher_url = "http://127.0.0.1:1080/messages"
+    messages = requests.get(mailcatcher_url, timeout=5).json()
+    # There should not be any message in mailcatcher before the test.
+    assert len(messages) == 0
+
+    with smtplib.SMTP(unit_ip) as server:
+        server.set_debuglevel(2)
+        from_addr = "Some One <someone@testrelay.internal>"
+        to_addrs = ["otherone@testrelay.internal"]
+        message = f"""\
+Subject: Hi Mailtrap
+To: {from_addr}
+From: {to_addrs[0]}
+This is my first message with Python."""
+        server.sendmail(from_addr=from_addr, to_addrs=to_addrs, msg=message)
+
+    for _ in range(5):
+        messages = requests.get(mailcatcher_url, timeout=5).json()
+        if messages:
+            break
+        time.sleep(1)
+    import pdb
+
+    pdb.set_trace()
+    assert len(messages) == 1
+    # message = requests.get(f"{mailcatcher_url}"/, timeout=5).json()
+
+    # Clean up mailcatcher
+    requests.delete(f"{mailcatcher_url}/{messages[0]['id']}", timeout=5)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -109,6 +109,7 @@ def test_simple_relay_dkim(
         lambda status: status.apps[smtp_relay_app].is_active,
         error=jubilant.any_blocked,
         timeout=6 * 60,
+        delay=10,
     )
 
     mailcatcher_url = "http://127.0.0.1:1080/messages"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -109,7 +109,7 @@ def test_simple_relay_dkim(
         lambda status: status.apps[smtp_relay_app].is_active,
         error=jubilant.any_blocked,
         timeout=6 * 60,
-        delay=10,
+        delay=5,
     )
 
     mailcatcher_url = "http://127.0.0.1:1080/messages"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -93,7 +93,7 @@ def test_simple_relay_dkim(
         {
             "selector": selector,
             "keytable": f"{selector}._domainkey.{domain} "
-            "{domain}:{selector}:/etc/dkimkeys/{domain}-{selector}.private",
+            f"{domain}:{selector}:/etc/dkimkeys/{domain}-{selector}.private",
             "signingtable": f"*@{domain} {selector}._domainkey.{domain}",
         },
     )

--- a/tox.ini
+++ b/tox.ini
@@ -101,22 +101,10 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.6.*
+    juju==3.6
     pytest
-    pytest-asyncio
     pytest-operator
+    jubilant == 1.4.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:src-docs]
-allowlist_externals=sh
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-description = Generate documentation for src
-deps =
-    lazydocs
-    -r{toxinidir}/requirements.txt
-commands =
-    ; can't run lazydocs directly due to needing to run it on src/* which produces an invocation error in tox
-    sh generate-src-docs.sh


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This PR prepares the charm to be packed. 

It adds a full integration test between smtp-relay and smtp-dkim-signing in which a message is signed.

A bug has been found, but it is not the purpose of this test to fix this, as the charm will be rewritten.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The changelog is updated.

<!-- Explanation for any unchecked items above -->
